### PR TITLE
Add a lookupPatterns option to handle custom module types

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,25 @@ var App = Ember.Application.create({
 });
 ```
 
+### Custom Lookup Patterns
+If you have a custom module type that you need to resolve, use the `lookupPatterns` option. It takes an array of functions with each function receiving a `parsedName` argument. The function optionally returns a `moduleName` value based on some criteria.
+
+``` javascript
+var reactModuleFilter = function(parsedName) {
+  if (parsedName.type === 'react') {
+    return './react/' + parsedName.fullNameWithoutType
+  }
+}
+
+var App = Ember.Application.create({
+  Resolver: require('ember-webpack-resolver?' + __dirname)({
+    extensions: ['.coffee', '.hbs'],
+    lookupPatterns: [reactModuleFilter]
+  })
+});
+
+```
+
 ### Resolving Components
 If you want to also resolve modules within vendor folders, a bit more configuration is required:
 

--- a/index.js
+++ b/index.js
@@ -48,6 +48,25 @@ module.exports = function(options) {
       moduleName = variations[0];
     }
 
+    /**
+      A possible array of functions to test for moduleName's based on the provided
+      `parsedName`. This allows easy customization of additional module based
+      lookup patterns.
+    */
+    if (Array.isArray(options.lookupPatterns)) {
+      for (var i = 0; i < options.lookupPatterns.length; i++) {
+        var lookupFn = options.lookupPatterns[i];
+        if (typeof lookupFn === 'function') {
+          var result = lookupFn(parsedName);
+          if (!(result === void 0)) {
+            moduleName = result;
+          }
+        } else {
+          throw new Error('Lookup patterns should be functions. Got type "' + typeof lookupFn + '" instead.');
+        }
+      }
+    }
+
     // If module not found, look if matches a specified component
     if (moduleName === false && parsedName.type === 'component' && options.components[parsedName.fullNameWithoutType]) {
       moduleName = parsedName.fullNameWithoutType;


### PR DESCRIPTION
Mimics the `moduleNameLookupPatterns` function in the original Ember Resolver. I needed a way to handle non-supported module types -- specifically when using Ember React.