### PR TITLE
Add toString functionality to better work with Ember 3

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ module.exports = function(options) {
     // To fix class introspection
     if (options.fixToString) {
       var className = factory.toString();
-      if (className.indexOf('(') !== -1) {
+      if (className.indexOf('(') !== -1 || className === "@ember/component") {
         factory.toString = getToStringFunction(parsedName.type, parsedName.fullNameWithoutType);
       }
     }
@@ -166,6 +166,9 @@ module.exports = function(options) {
     resolveTemplate: resolveOther, // TODO: Check Ember.TEMPLATES as backup
     resolveRouter: resolveRouter,
     parseName: parseName,
+    makeToString(factory, fullName) {
+        return '' + options.modulePrefix + '@' + fullName + ':';
+    },
     normalize: function(fullName) {
       // replace `.` with `/` in order to make nested controllers work in the following cases
       // 1. `needs: ['posts/post']`


### PR DESCRIPTION
Adding a makeToString function to the resolver like Ember's DefaultResolver has https://github.com/ember-cli/ember-resolver/blame/59d6e19cfd19c8f16f6f1cada771112da6231b9a/addon/resolvers/classic/index.js#L119 makes the Ember Inspector Chrome addon work correctly. Also, if you want nicer toString functions of the actual classes, Ember 3 now defaults to "@ember/component", so you need to check for that string to override.

Without this change, the Ember Inspector chrome addon looks like this (just a bunch of @ember/component):

![Screen Shot 2020-02-25 at 11 40 18 PM](https://user-images.githubusercontent.com/2659793/75312544-3affcc00-5828-11ea-8290-c290a01ef277.png)
