### PR TITLE
Allow the router resolver to work with export default

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,7 +156,9 @@ module.exports = function(options) {
     if (parsedName.fullName === 'router:main') {
       var name = options.modulePrefix + 'router';
       if (options.context.keys().indexOf(name) !== -1) {
-        return options.context(name);
+        var context = options.context(name);
+        var isModule = typeof context === "object" && typeof context.default === "function";
+        return isModule ? context.default : context;
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ember-webpack-resolver",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "An Ember resolver for use with webpack",
     "main": "index.js",
     "files": [

--- a/test/router.js
+++ b/test/router.js
@@ -1,6 +1,8 @@
-const Router = module.exports = Ember.Router.extend({
+const Router = Ember.Router.extend({
   location: "history"
 })
+
+export default Router
 
 Router.map(function() {
   this.route('bear')


### PR DESCRIPTION
If you're on a newer Ember version, then you'll be doing `import EmberRouter from '@ember/routing/router'` rather
then calling the `Ember.Router` global directly. This means you have to do an `export default` instead of `module.exports =`.

In that situation, `options.context(name)` returns the module, and we need to call the default export on it.

Example migration where this change is necessary:

From:

```
const Router = module.exports = Ember.Router.extend({
  location: "history"
})

Router.map(function() {
  this.route('bear')
})
```

To:

```
import EmberRouter from "@ember/routing/router"; // Can't mix `import` and `module.exports`

const Router = EmberRouter.extend({
  location: "history"
})

export default Router

Router.map(function() {
  this.route('bear')
})
```