### PR TITLE
Support pods in a podModulePrefix directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ module.exports = function(options) {
   }
 
   options.modulePrefix = options.modulePrefix || './';
+  options.podModulePrefix = options.podModulePrefix || "pods";
   options.extensions = options.extensions || ['.js', '.hbs'];
   options.fixToString = options.fixToString !== false;
   options.has = options.has || options.context.keys();
@@ -56,10 +57,14 @@ module.exports = function(options) {
       podVariation = options.modulePrefix + parsedName.fullNameWithoutType.slice(11) + '/' + parsedName.type;
       withinComponentPodVariation = options.modulePrefix + 'components/' + parsedName.fullNameWithoutType.slice(11) + '/' + parsedName.type;
     }
+
+    var withinPodModulePrefixVariation = "./" + options.podModulePrefix + podVariation.slice(1);
+
     var variations = [
       podVariation,
       options.modulePrefix + parsedName.type + 's/' + parsedName.fullNameWithoutType,
-      withinComponentPodVariation
+      withinComponentPodVariation,
+      withinPodModulePrefixVariation
     ];
     var contextrequire = options.context;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ember-webpack-resolver",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "An Ember resolver for use with webpack",
     "main": "index.js",
     "files": [


### PR DESCRIPTION
This PR allows you to define a `podModulePrefix`, where you can place your pod style components (outside of the `components` directory).

`ember-cli` expects you to define a `podModulePrefix`, so this PR acts as a stepping stone for being able to migrate from Webpack to `ember-cli`.

e.g.:

```
const App = Ember.Application.create({
  Resolver: require('ember-webpack-resolver?' + __dirname)({
    podModulePrefix: "pods"
  })
});
```

Project layout example:

```
app
└── pods
    ├── components
    |   └── tags
    |       ├── component.js
    |       └── template.hbs
    └── post
        ├── controller.js
        ├── model.js
        ├── route.js
        └── template.hbs
```

[Ember docs reference on Pod layouts](https://cli.emberjs.com/release/advanced-use/project-layouts/)